### PR TITLE
fix: don't expose global process.env type to consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,5 @@
+/// <reference types="node" />
 import { compose } from "redux";
-
-declare global {
-  const process: {
-    env: {
-      NODE_ENV: "development" | "production";
-    };
-  };
-}
 
 export let composeWithDevTools: typeof import("./devtools").composeWithDevTools;
 let devtoolsEnhancer: typeof import("./devtools").default;


### PR DESCRIPTION
Before this, consumers of the plugin would pick up the `process.env` type declaration in `src/index.ts`, which only typed the `NODE_ENV` field, rather than the full type of `process.env`. By using the types from `node` to get the `process.env` type within the plugin, we avoid interfering with consumer's type information.

For some reason, the normal approach of installing the `@types/node` package, and specifying `types: ["node"]` in `tsconfig.json` wasn't working, so instead this uses a triple-slash reference comment in the one file where it's needed.

Testing: used `yarn link` to use this updated version in my Expo app and the `Property 'SOME_PROPERTY' does not exist on type '{ NODE_ENV: "development" | "production"; }'.` errors went away.