### PR TITLE
Redux Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ yarn add redux-devtools-expo-dev-plugin
 
 ### Link the DevTools to Redux
 
-There are 3 ways of using this package depending if you're using Redux Toolkit, or standard Redux with other store enhancers (middlewares) or not.
+There are multiple ways of using this package depending if you're using Redux Toolkit, or standard Redux with other store enhancers (middlewares) or not.
 
 #### Using Redux Toolkit
 Let's suppose your store looks something like this:
@@ -76,6 +76,84 @@ const store = configureStore({
   reducer: rootReducer,
   middleware: getDefaultMiddleware => getDefaultMiddleware(defaultMiddlewareOptions),
 });
+```
+
+#### `redux` without other enhancers
+
+If you have the legacy basic [store](http://redux.js.org/docs/api/createStore.html) as described in the official [redux-docs](http://redux.js.org/index.html), simply replace:
+
+```javascript
+import { createStore } from "redux";
+const store = createStore(reducer);
+```
+
+with:
+
+```javascript
+import { createStore } from "redux";
+import { devToolsEnhancer } from "redux-devtools-expo-dev-plugin";
+const store = createStore(reducer, devToolsEnhancer());
+// or const store = createStore(reducer, preloadedState, devToolsEnhancer());
+```
+
+or with options:
+
+```javascript
+import { createStore } from "redux";
+import { devToolsEnhancer } from "redux-devtools-expo-dev-plugin";
+const store = createStore(reducer, devToolsEnhancer({ trace: true }));
+```
+
+> Note: passing enhancer as last argument requires redux@>=3.1.0
+
+#### `redux` with other enhancers
+
+If you setup your store with [middlewares and enhancers](http://redux.js.org/docs/api/applyMiddleware.html) like [redux-saga](https://github.com/redux-saga/redux-saga) and similar, it is crucial to use `composeWithDevTools` export. Otherwise, actions dispatched from Redux DevTools will not flow to your middlewares.
+
+In that case change this:
+
+```javascript
+import { createStore, applyMiddleware, compose } from "redux";
+
+const store = createStore(
+  reducer,
+  preloadedState,
+  compose(
+    applyMiddleware(...middleware),
+    // other store enhancers if any
+  ),
+);
+```
+
+to:
+
+```javascript
+import { createStore, applyMiddleware } from "redux";
+import { composeWithDevTools } from "redux-devtools-expo-dev-plugin";
+
+const store = createStore(
+  reducer,
+  /* preloadedState, */ composeWithDevTools(
+    applyMiddleware(...middleware),
+    // other store enhancers if any
+  ),
+);
+```
+
+or with options:
+
+```javascript
+import { createStore, applyMiddleware } from "redux";
+import { composeWithDevTools } from "redux-devtools-expo-dev-plugin";
+
+const composeEnhancers = composeWithDevTools({ trace: true });
+const store = createStore(
+  reducer,
+  /* preloadedState, */ composeEnhancers(
+    applyMiddleware(...middleware),
+    // other store enhancers if any
+  ),
+);
 ```
 
 ## Using the DevTools

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "jsan": "^3.1.14"
       },
       "devDependencies": {
+        "@reduxjs/toolkit": "^2.2.5",
         "@types/jsan": "^3.1.5",
         "expo": "~50.0.17",
         "expo-module-scripts": "^3.4.2",
@@ -4216,6 +4217,30 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.5.tgz",
+      "integrity": "sha512-aeFA/s5NCG7NoJe/MhmwREJxRkDs0ZaSqt0MxhWUrwCf1UQXpwR87RROJEql0uAkLI6U7snBOYOcKw83ew3FPg==",
+      "dev": true,
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@segment/loosely-validate-event": {
@@ -8770,6 +8795,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/immutable": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
@@ -12825,6 +12860,15 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "dev": true,
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -12998,6 +13042,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "dev": true
     },
     "node_modules/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,10 @@
         "expo": "~50.0.17",
         "expo-module-scripts": "^3.4.2",
         "patch-package": "^8.0.0",
-        "redux": "^5.0.1",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "expo": "*",
-        "redux": "*"
+        "expo": "*"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jsan": "^3.1.14"
   },
   "devDependencies": {
+    "@reduxjs/toolkit": "^2.2.5",
     "@types/jsan": "^3.1.5",
     "expo": "~50.0.17",
     "expo-module-scripts": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "expo": "~50.0.17",
     "expo-module-scripts": "^3.4.2",
     "patch-package": "^8.0.0",
-    "redux": "^5.0.1",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -17,18 +17,18 @@ import {
   LocalFilter,
   State,
 } from "@redux-devtools/utils";
-import { StoreEnhancer } from "@reduxjs/toolkit";
+import {
+  Action,
+  ActionCreator,
+  Reducer,
+  StoreEnhancer,
+  StoreEnhancerStoreCreator,
+} from "@reduxjs/toolkit";
 import {
   DevToolsPluginClient,
   getDevToolsPluginClientAsync,
 } from "expo/devtools";
 import { stringify, parse } from "jsan";
-import {
-  Action,
-  ActionCreator,
-  Reducer,
-  StoreEnhancerStoreCreator,
-} from "redux";
 
 import configureStore from "./configureStore";
 

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -17,6 +17,7 @@ import {
   LocalFilter,
   State,
 } from "@redux-devtools/utils";
+import { StoreEnhancer } from "@reduxjs/toolkit";
 import {
   DevToolsPluginClient,
   getDevToolsPluginClientAsync,
@@ -26,7 +27,6 @@ import {
   Action,
   ActionCreator,
   Reducer,
-  StoreEnhancer,
   StoreEnhancerStoreCreator,
 } from "redux";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { compose } from "redux";
+import { compose } from "@reduxjs/toolkit";
 
 declare global {
   const process: {


### PR DESCRIPTION
### Description:

Hello! Those suggestions made it possible for us to use this plugin with Redux Toolkit. 

Should fix #4 and #8 
Did not test with Redux Saga though

### Changes:

Besides using the `StoreEnhancer` type exported by `redux-toolkit` instead of `redux`, the following setup made it possible for us with no errors, `ts-ignore`, or other hacks:

#### Using Redux Toolkit
Let's suppose your store looks something like this:

```ts
import { configureStore } from '@reduxjs/toolkit';

const defaultMiddlewareOptions = {
  serializableCheck: false,
  immutableCheck,
};

const middlewares = [apiSlice.middleware, resourcesApiSlice.middleware];

const store = configureStore({
  reducer: rootReducer,
  middleware: getDefaultMiddleware => getDefaultMiddleware(defaultMiddlewareOptions).concat(middlewares),
});
```

After adding the plugin it should look something like this:


```ts
import { StoreEnhancer, configureStore } from '@reduxjs/toolkit';
import devToolsEnhancer from 'redux-devtools-expo-dev-plugin';
import { applyMiddleware } from '@reduxjs/toolkit';

const defaultMiddlewareOptions = {
  serializableCheck: false,
  immutableCheck,
};

const middlewareEnhancer = applyMiddleware(
  apiSlice.middleware,
  resourcesApiSlice.middleware,
);

const store = configureStore({
  enhancers: getDefaultEnhancers =>
    getDefaultEnhancers().concat(middlewareEnhancer, devToolsEnhancer()),
  reducer: rootReducer,
  middleware: getDefaultMiddleware => getDefaultMiddleware(defaultMiddlewareOptions),
});
```