### PR TITLE
fix: bump redux-devtools-expo-dev-plugin version in example

### DIFF
--- a/examples/example-redux-toolkit/package-lock.json
+++ b/examples/example-redux-toolkit/package-lock.json
@@ -14,7 +14,7 @@
         "react": "18.3.1",
         "react-native": "0.76.2",
         "react-redux": "^9.1.2",
-        "redux-devtools-expo-dev-plugin": "^0.2.1"
+        "redux-devtools-expo-dev-plugin": "^1.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -10220,9 +10220,9 @@
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-devtools-expo-dev-plugin": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/redux-devtools-expo-dev-plugin/-/redux-devtools-expo-dev-plugin-0.2.1.tgz",
-      "integrity": "sha512-wzSZ/DDa1QoQ/Uh1BdtJJdFDj0URXXknkHNcO+Q2A3Pbt7LTku1gAuzIMdy36ET7Pp7ge+UDj2OAEpe6kyQqPA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redux-devtools-expo-dev-plugin/-/redux-devtools-expo-dev-plugin-1.0.0.tgz",
+      "integrity": "sha512-E97ZAlswpkSE5ZwcWTKCFT9PEwDs2JBS8UvmW99PWtN3i6BRLmDo+iUwjIlMIfCEHkYiWtWE9JoYflNN3v57Ow==",
       "license": "MIT",
       "dependencies": {
         "@redux-devtools/instrument": "^2.2.0",
@@ -10230,7 +10230,7 @@
         "jsan": "^3.1.14"
       },
       "peerDependencies": {
-        "expo": "*",
+        "expo": ">=52",
         "redux": "*"
       }
     },

--- a/examples/example-redux-toolkit/package.json
+++ b/examples/example-redux-toolkit/package.json
@@ -15,7 +15,7 @@
     "react": "18.3.1",
     "react-native": "0.76.2",
     "react-redux": "^9.1.2",
-    "redux-devtools-expo-dev-plugin": "^0.2.1"
+    "redux-devtools-expo-dev-plugin": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
@matt-oakes - I think that you just forgot to update the plugin version in the example :) You updated expo and everything else, but left the old version of the package there :)

More context: https://github.com/matt-oakes/redux-devtools-expo-dev-plugin/pull/15