### PR TITLE
Create abstraction for communication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,22 @@
 /// <reference types="node" />
 import { compose } from "redux";
 
-export let composeWithDevTools: typeof import("./devtools").composeWithDevTools;
-let devtoolsEnhancer: typeof import("./devtools").default;
+export let createComposeWithDevTools: typeof import("./devtools").createComposeWithDevTools;
+export let composeWithDevTools: ReturnType<typeof createComposeWithDevTools>;
+
+let createDevToolsEnhancer: typeof import("./devtools").createDevToolsEnhancer;
+let devtoolsEnhancer: ReturnType<typeof createDevToolsEnhancer>;
 
 if (process.env.NODE_ENV !== "production") {
-  devtoolsEnhancer = require("./devtools").default;
-  composeWithDevTools = require("./devtools").composeWithDevTools;
+  const getDevToolsPluginClientAsync = require('expo/devtools');
+  const createDevToolsEnhancer = require("./devtools").createDevToolsEnhancer;
+
+  devtoolsEnhancer = createDevToolsEnhancer(() => getDevToolsPluginClientAsync("redux-devtools-expo-dev-plugin"));
+  createComposeWithDevTools = require("./devtools").createComposeWithDevTools;
+  composeWithDevTools = createComposeWithDevTools(() => getDevToolsPluginClientAsync("redux-devtools-expo-dev-plugin"));
 } else {
   devtoolsEnhancer = () => (next) => next;
+  createComposeWithDevTools = () => compose;
   composeWithDevTools = compose;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ let createDevToolsEnhancer: typeof import("./devtools").createDevToolsEnhancer;
 let devtoolsEnhancer: ReturnType<typeof createDevToolsEnhancer>;
 
 if (process.env.NODE_ENV !== "production") {
-  const getDevToolsPluginClientAsync = require('expo/devtools');
+  const getDevToolsPluginClientAsync = require('expo/devtools').getDevToolsPluginClientAsync;
   const createDevToolsEnhancer = require("./devtools").createDevToolsEnhancer;
 
   devtoolsEnhancer = createDevToolsEnhancer(() => getDevToolsPluginClientAsync("redux-devtools-expo-dev-plugin"));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,7 @@
+export interface ProxyClient {
+  sendMessage: (type: string, data?: any) => void;
+  addMessageListener: (method: string, listener: (params: any) => void) => void;
+  closeAsync: () => Promise<void>;
+}
+
+export type ProxyClientFactory = () => Promise<ProxyClient>;

--- a/webui/src/middlewares/types.ts
+++ b/webui/src/middlewares/types.ts
@@ -1,0 +1,6 @@
+export interface ProxyClient {
+  sendMessage: (type: string, data?: any) => void;
+  addMessageListener: (method: string, listener: (params: any) => void) => void;
+}
+
+export type ProxyClientFactory = () => Promise<ProxyClient>;

--- a/webui/src/store/configureStore.ts
+++ b/webui/src/store/configureStore.ts
@@ -4,7 +4,6 @@ import { createStore, compose, applyMiddleware } from "redux";
 import { persistReducer, persistStore } from "redux-persist";
 
 import { api } from "../middlewares/api";
-import { createRNIDEProxyClientAsync } from "../middlewares/radon_proxy";
 import { rootReducer } from "../reducers";
 
 const persistConfig = {

--- a/webui/src/store/configureStore.ts
+++ b/webui/src/store/configureStore.ts
@@ -4,6 +4,7 @@ import { createStore, compose, applyMiddleware } from "redux";
 import { persistReducer, persistStore } from "redux-persist";
 
 import { api } from "../middlewares/api";
+import { createRNIDEProxyClientAsync } from "../middlewares/radon_proxy";
 import { rootReducer } from "../reducers";
 
 const persistConfig = {
@@ -35,7 +36,7 @@ export default function configureStore() {
   const store = createStore(
     persistedReducer,
     /// @ts-expect-error
-    composeEnhancers(applyMiddleware(...middlewares, api)),
+    composeEnhancers(applyMiddleware(...middlewares, api())),
   );
   const persistor = persistStore(store);
   return { store, persistor };


### PR DESCRIPTION
This PRs adds abstraction to `redux-devtools-expo-devplugin`. This change will help separate the communication logic and the devtools part itself. I wanted to reuse the library for Radon IDE, but I need a different way to communicate than `expo/devtools`. It shouldn't impact the behavior of `redux-devtools-epo-dev-plugin` in any way, we will keep our implementation on our fork.  The abstraction is added on both "sides": in the dev tools webui and redux enhancer/compose.

**How it has been tested:** 
- build the package locally
- install from local .tgz in https://github.com/software-mansion-labs/radon-ide-test-apps/tree/main/expo-52-prebuild-with-plugins
- start the app
- shift + m 
- confirm that dev-plugins are still working 
